### PR TITLE
feat: add Administrador model with permission system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist
 
 .env
+ADMIN_*

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -377,6 +377,106 @@ const options = {
             },
           },
         },
+        Administrador: {
+          type: 'object',
+          required: ['userId', 'nivel'],
+          properties: {
+            id: {
+              type: 'integer',
+              description: 'ID único do administrador',
+              example: 1,
+            },
+            userId: {
+              type: 'integer',
+              description: 'ID do usuário associado',
+              example: 1,
+            },
+            nivel: {
+              type: 'string',
+              enum: ['super', 'moderador', 'suporte'],
+              description: 'Nível de acesso do administrador',
+              example: 'moderador',
+            },
+            permissoes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Lista de permissões específicas',
+              example: ['gerenciar_usuarios', 'visualizar_relatorios'],
+            },
+            ativo: {
+              type: 'boolean',
+              description: 'Se o administrador está ativo',
+              example: true,
+            },
+            dataCriacao: {
+              type: 'string',
+              format: 'date-time',
+              description: 'Data de criação do administrador',
+              example: '2025-01-20T10:00:00.000Z',
+            },
+            dataAtualizacao: {
+              type: 'string',
+              format: 'date-time',
+              description: 'Data da última atualização',
+              example: '2025-01-20T15:30:00.000Z',
+            },
+            user: {
+              $ref: '#/components/schemas/User',
+              description: 'Dados do usuário associado',
+            },
+          },
+        },
+        AdministradorInput: {
+          type: 'object',
+          required: ['userId', 'nivel'],
+          properties: {
+            userId: {
+              type: 'integer',
+              description: 'ID do usuário que será administrador',
+              example: 1,
+            },
+            nivel: {
+              type: 'string',
+              enum: ['super', 'moderador', 'suporte'],
+              description: 'Nível de acesso do administrador',
+              example: 'moderador',
+            },
+            permissoes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Lista de permissões específicas (opcional)',
+              example: ['gerenciar_usuarios', 'visualizar_relatorios'],
+            },
+          },
+        },
+        AdministradorUpdateInput: {
+          type: 'object',
+          properties: {
+            nivel: {
+              type: 'string',
+              enum: ['super', 'moderador', 'suporte'],
+              description: 'Nível de acesso do administrador',
+              example: 'moderador',
+            },
+            permissoes: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description: 'Lista de permissões específicas',
+              example: ['gerenciar_usuarios', 'visualizar_relatorios'],
+            },
+            ativo: {
+              type: 'boolean',
+              description: 'Se o administrador está ativo',
+              example: true,
+            },
+          },
+        },
         Error: {
           type: 'object',
           properties: {

--- a/src/controllers/administradorController.ts
+++ b/src/controllers/administradorController.ts
@@ -1,0 +1,228 @@
+import { Request, Response } from "express";
+import { AdministradorService, CreateAdministradorDTO, UpdateAdministradorDTO } from "../services/administradorService";
+
+export class AdministradorController {
+    private administradorService: AdministradorService;
+
+    constructor() {
+        this.administradorService = new AdministradorService();
+    }
+
+    // POST /administradores - Criar administrador
+    createAdministrador = async (req: Request, res: Response) => {
+        try {
+            const data: CreateAdministradorDTO = req.body;
+            const administrador = await this.administradorService.createAdministrador(data);
+            res.status(201).json(administrador);
+        } catch (error: any) {
+            res.status(400).json({
+                message: "Erro ao criar o administrador",
+                error: error.message
+            });
+        }
+    };
+
+    // GET /administradores - Obter todos os administradores
+    getAllAdministradores = async (req: Request, res: Response) => {
+        try {
+            const administradores = await this.administradorService.getAllAdministradores();
+            res.json(administradores);
+        } catch (error: any) {
+            res.status(500).json({
+                message: "Erro ao obter os administradores",
+                error: error.message
+            });
+        }
+    };
+
+    // GET /administradores/:id - Obter administrador por ID
+    getAdministradorById = async (req: Request, res: Response) => {
+        try {
+            const id = Number(req.params.id);
+            const administrador = await this.administradorService.getAdministradorById(id);
+            res.json(administrador);
+        } catch (error: any) {
+            if (error.message === "Administrador não encontrado" || error.message === "ID do administrador inválido") {
+                res.status(404).json({ message: error.message });
+            } else {
+                res.status(500).json({
+                    message: "Erro ao obter o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // GET /administradores/usuario/:userId - Obter administrador por ID do usuário
+    getAdministradorByUserId = async (req: Request, res: Response) => {
+        try {
+            const userId = Number(req.params.userId);
+            const administrador = await this.administradorService.getAdministradorByUserId(userId);
+            
+            if (!administrador) {
+                return res.status(404).json({ message: "Este usuário não é um administrador" });
+            }
+            
+            res.json(administrador);
+        } catch (error: any) {
+            if (error.message === "ID do usuário inválido") {
+                res.status(400).json({ message: error.message });
+            } else {
+                res.status(500).json({
+                    message: "Erro ao obter o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // GET /administradores/nivel/:nivel - Obter administradores por nível
+    getAdministradoresByNivel = async (req: Request, res: Response) => {
+        try {
+            const nivel = req.params.nivel as 'super' | 'moderador' | 'suporte';
+            
+            if (!['super', 'moderador', 'suporte'].includes(nivel)) {
+                return res.status(400).json({ message: "Nível inválido. Use: super, moderador ou suporte" });
+            }
+            
+            const administradores = await this.administradorService.getAdministradoresByNivel(nivel);
+            res.json(administradores);
+        } catch (error: any) {
+            res.status(500).json({
+                message: "Erro ao obter os administradores",
+                error: error.message
+            });
+        }
+    };
+
+    // GET /administradores/ativos - Obter administradores ativos
+    getAdministradoresAtivos = async (req: Request, res: Response) => {
+        try {
+            const administradores = await this.administradorService.getAdministradoresAtivos();
+            res.json(administradores);
+        } catch (error: any) {
+            res.status(500).json({
+                message: "Erro ao obter os administradores ativos",
+                error: error.message
+            });
+        }
+    };
+
+    // PUT /administradores/:id - Atualizar administrador
+    updateAdministrador = async (req: Request, res: Response) => {
+        try {
+            const id = Number(req.params.id);
+            const data: UpdateAdministradorDTO = req.body;
+            const administrador = await this.administradorService.updateAdministrador(id, data);
+            res.json(administrador);
+        } catch (error: any) {
+            if (error.message === "Administrador não encontrado" || error.message === "ID do administrador inválido") {
+                res.status(404).json({ message: error.message });
+            } else {
+                res.status(400).json({
+                    message: "Erro ao atualizar o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // PATCH /administradores/:id/ativar - Ativar administrador
+    ativarAdministrador = async (req: Request, res: Response) => {
+        try {
+            const id = Number(req.params.id);
+            const administrador = await this.administradorService.ativarAdministrador(id);
+            res.json({
+                message: "Administrador ativado com sucesso",
+                administrador
+            });
+        } catch (error: any) {
+            if (error.message === "Administrador não encontrado" || error.message === "ID do administrador inválido") {
+                res.status(404).json({ message: error.message });
+            } else {
+                res.status(500).json({
+                    message: "Erro ao ativar o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // PATCH /administradores/:id/desativar - Desativar administrador
+    desativarAdministrador = async (req: Request, res: Response) => {
+        try {
+            const id = Number(req.params.id);
+            const administrador = await this.administradorService.desativarAdministrador(id);
+            res.json({
+                message: "Administrador desativado com sucesso",
+                administrador
+            });
+        } catch (error: any) {
+            if (error.message === "Administrador não encontrado" || error.message === "ID do administrador inválido") {
+                res.status(404).json({ message: error.message });
+            } else {
+                res.status(500).json({
+                    message: "Erro ao desativar o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // DELETE /administradores/:id - Deletar administrador
+    deleteAdministrador = async (req: Request, res: Response) => {
+        try {
+            const id = Number(req.params.id);
+            const result = await this.administradorService.deleteAdministrador(id);
+            res.json(result);
+        } catch (error: any) {
+            if (error.message === "Administrador não encontrado" || error.message === "ID do administrador inválido") {
+                res.status(404).json({ message: error.message });
+            } else {
+                res.status(500).json({
+                    message: "Erro ao deletar o administrador",
+                    error: error.message
+                });
+            }
+        }
+    };
+
+    // POST /administradores/verificar-permissao - Verificar permissão do usuário
+    verificarPermissao = async (req: Request, res: Response) => {
+        try {
+            const { userId, permissao } = req.body;
+            
+            if (!userId || !permissao) {
+                return res.status(400).json({ message: "userId e permissao são obrigatórios" });
+            }
+            
+            const temPermissao = await this.administradorService.verificarPermissao(userId, permissao);
+            res.json({
+                userId,
+                permissao,
+                temPermissao
+            });
+        } catch (error: any) {
+            res.status(500).json({
+                message: "Erro ao verificar permissão",
+                error: error.message
+            });
+        }
+    };
+
+    // GET /administradores/permissoes - Obter lista de permissões disponíveis
+    getPermissoesDisponiveis = async (req: Request, res: Response) => {
+        try {
+            const permissoes = await this.administradorService.getPermissoesDisponiveis();
+            res.json({
+                permissoes,
+                total: permissoes.length
+            });
+        } catch (error: any) {
+            res.status(500).json({
+                message: "Erro ao obter permissões disponíveis",
+                error: error.message
+            });
+        }
+    };
+}

--- a/src/models/Administrador.ts
+++ b/src/models/Administrador.ts
@@ -1,0 +1,68 @@
+import { Model, DataTypes, Optional } from 'sequelize';
+import sequelize from '../config/database';
+
+interface AdministradorCreationAttributes extends Optional<AdministradorAttributes, 'id'> {}
+
+interface AdministradorAttributes {
+  id: number;
+  userId: number;
+  nivel: 'super' | 'moderador' | 'suporte';
+  permissoes: string[];
+  dataAtivacao: Date;
+  ativo: boolean;
+}
+
+export class Administrador extends Model<AdministradorAttributes, AdministradorCreationAttributes> implements AdministradorAttributes {
+  public id!: number;
+  public userId!: number;
+  public nivel!: 'super' | 'moderador' | 'suporte';
+  public permissoes!: string[];
+  public dataAtivacao!: Date;
+  public ativo!: boolean;
+}
+
+Administrador.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'users',
+        key: 'id',
+      },
+    },
+    nivel: {
+      type: DataTypes.ENUM('super', 'moderador', 'suporte'),
+      allowNull: false,
+      defaultValue: 'suporte',
+    },
+    permissoes: {
+      type: DataTypes.JSON,
+      allowNull: false,
+      defaultValue: [],
+    },
+    dataAtivacao: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    ativo: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+  },
+  {
+    sequelize,
+    tableName: "administradores",
+    timestamps: false,
+  }
+);
+
+export default Administrador;

--- a/src/repositories/administradorRepository.ts
+++ b/src/repositories/administradorRepository.ts
@@ -1,0 +1,129 @@
+import { Administrador } from "../models/Administrador";
+import { User } from "../models/User";
+
+export interface UpdateAdministradorData {
+    nivel?: 'super' | 'moderador' | 'suporte';
+    permissoes?: string[];
+    ativo?: boolean;
+}
+
+export class AdministradorRepository {
+    
+    async createAdministrador(
+        userId: number,
+        nivel: 'super' | 'moderador' | 'suporte',
+        permissoes: string[] = [],
+        ativo: boolean = true
+    ) {
+        return await Administrador.create({
+            userId,
+            nivel,
+            permissoes,
+            dataAtivacao: new Date(),
+            ativo
+        });
+    }
+    
+    async getAllAdministradores() {
+        return await Administrador.findAll({
+            include: [{
+                model: User,
+                attributes: ['id', 'name', 'email']
+            }]
+        });
+    }
+
+    async getAdministradorById(id: number) {
+        return await Administrador.findByPk(id, {
+            include: [{
+                model: User,
+                attributes: ['id', 'name', 'email']
+            }]
+        });
+    }
+
+    async getAdministradorByUserId(userId: number) {
+        return await Administrador.findOne({
+            where: { userId },
+            include: [{
+                model: User,
+                attributes: ['id', 'name', 'email']
+            }]
+        });
+    }
+
+    async getAdministradoresByNivel(nivel: 'super' | 'moderador' | 'suporte') {
+        return await Administrador.findAll({
+            where: { nivel },
+            include: [{
+                model: User,
+                attributes: ['id', 'name', 'email']
+            }]
+        });
+    }
+
+    async getAdministradoresAtivos() {
+        return await Administrador.findAll({
+            where: { ativo: true },
+            include: [{
+                model: User,
+                attributes: ['id', 'name', 'email']
+            }]
+        });
+    }
+
+    async updateAdministrador(id: number, data: UpdateAdministradorData) {
+        const administrador = await Administrador.findByPk(id);
+        if (!administrador) {
+            throw new Error("Administrador não encontrado");
+        }
+        
+        await administrador.update(data);
+        return administrador;
+    }
+
+    async ativarAdministrador(id: number) {
+        const administrador = await Administrador.findByPk(id);
+        if (!administrador) {
+            throw new Error("Administrador não encontrado");
+        }
+        
+        await administrador.update({ ativo: true });
+        return administrador;
+    }
+
+    async desativarAdministrador(id: number) {
+        const administrador = await Administrador.findByPk(id);
+        if (!administrador) {
+            throw new Error("Administrador não encontrado");
+        }
+        
+        await administrador.update({ ativo: false });
+        return administrador;
+    }
+
+    async deleteAdministrador(id: number) {
+        const administrador = await Administrador.findByPk(id);
+        if (!administrador) {
+            throw new Error("Administrador não encontrado");
+        }
+        
+        await administrador.destroy();
+        return { message: "Administrador removido com sucesso" };
+    }
+
+    async verificarPermissao(userId: number, permissao: string): Promise<boolean> {
+        const administrador = await this.getAdministradorByUserId(userId);
+        
+        if (!administrador || !administrador.ativo) {
+            return false;
+        }
+        
+        // Super administradores têm todas as permissões
+        if (administrador.nivel === 'super') {
+            return true;
+        }
+        
+        return administrador.permissoes.includes(permissao);
+    }
+}

--- a/src/routes/administradorExtendedRoutes.ts
+++ b/src/routes/administradorExtendedRoutes.ts
@@ -1,0 +1,137 @@
+import { Router } from "express";
+import { AdministradorController } from "../controllers/administradorController";
+
+const router = Router();
+const administradorController = new AdministradorController();
+
+/**
+ * @swagger
+ * /administradores/usuario/{userId}:
+ *   get:
+ *     summary: Obter administrador por ID do usuário
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do usuário
+ *     responses:
+ *       200:
+ *         description: Administrador encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Administrador'
+ *       404:
+ *         description: Este usuário não é um administrador
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/usuario/:userId", (req, res) => {
+    administradorController.getAdministradorByUserId(req, res);
+});
+
+/**
+ * @swagger
+ * /administradores/nivel/{nivel}:
+ *   get:
+ *     summary: Obter administradores por nível
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: nivel
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [super, moderador, suporte]
+ *         description: Nível do administrador
+ *     responses:
+ *       200:
+ *         description: Lista de administradores do nível especificado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Administrador'
+ *       400:
+ *         description: Nível inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/nivel/:nivel", (req, res) => {
+    administradorController.getAdministradoresByNivel(req, res);
+});
+
+/**
+ * @swagger
+ * /administradores/verificar-permissao:
+ *   post:
+ *     summary: Verificar se um usuário tem uma permissão específica
+ *     tags: [Administradores]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [userId, permissao]
+ *             properties:
+ *               userId:
+ *                 type: integer
+ *                 description: ID do usuário
+ *                 example: 1
+ *               permissao:
+ *                 type: string
+ *                 description: Nome da permissão a verificar
+ *                 example: "gerenciar_usuarios"
+ *     responses:
+ *       200:
+ *         description: Resultado da verificação de permissão
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 userId:
+ *                   type: integer
+ *                 permissao:
+ *                   type: string
+ *                 temPermissao:
+ *                   type: boolean
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.post("/verificar-permissao", (req, res) => {
+    administradorController.verificarPermissao(req, res);
+});
+
+export default router;

--- a/src/routes/administradorRoutes.ts
+++ b/src/routes/administradorRoutes.ts
@@ -1,0 +1,321 @@
+import { Router } from "express";
+import { AdministradorController } from "../controllers/administradorController";
+
+const router = Router();
+const administradorController = new AdministradorController();
+
+/**
+ * @swagger
+ * /administradores:
+ *   post:
+ *     summary: Criar um novo administrador
+ *     tags: [Administradores]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdministradorInput'
+ *     responses:
+ *       201:
+ *         description: Administrador criado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Administrador'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.post("/", administradorController.createAdministrador);
+
+/**
+ * @swagger
+ * /administradores:
+ *   get:
+ *     summary: Obter todos os administradores
+ *     tags: [Administradores]
+ *     responses:
+ *       200:
+ *         description: Lista de administradores retornada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Administrador'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/", administradorController.getAllAdministradores);
+
+/**
+ * @swagger
+ * /administradores/permissoes:
+ *   get:
+ *     summary: Obter lista de permissões disponíveis
+ *     tags: [Administradores]
+ *     responses:
+ *       200:
+ *         description: Lista de permissões disponíveis
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 permissoes:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                 total:
+ *                   type: integer
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/permissoes", administradorController.getPermissoesDisponiveis);
+
+/**
+ * @swagger
+ * /administradores/ativos:
+ *   get:
+ *     summary: Obter administradores ativos
+ *     tags: [Administradores]
+ *     responses:
+ *       200:
+ *         description: Lista de administradores ativos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Administrador'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/ativos", administradorController.getAdministradoresAtivos);
+
+/**
+ * @swagger
+ * /administradores/{id}:
+ *   get:
+ *     summary: Obter administrador por ID
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do administrador
+ *     responses:
+ *       200:
+ *         description: Administrador encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Administrador'
+ *       404:
+ *         description: Administrador não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.get("/:id", administradorController.getAdministradorById);
+
+/**
+ * @swagger
+ * /administradores/{id}:
+ *   put:
+ *     summary: Atualizar administrador
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do administrador
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdministradorUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Administrador atualizado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Administrador'
+ *       404:
+ *         description: Administrador não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.put("/:id", administradorController.updateAdministrador);
+
+/**
+ * @swagger
+ * /administradores/{id}/ativar:
+ *   patch:
+ *     summary: Ativar administrador
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do administrador
+ *     responses:
+ *       200:
+ *         description: Administrador ativado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Administrador ativado com sucesso"
+ *                 administrador:
+ *                   $ref: '#/components/schemas/Administrador'
+ *       404:
+ *         description: Administrador não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.patch("/:id/ativar", administradorController.ativarAdministrador);
+
+/**
+ * @swagger
+ * /administradores/{id}/desativar:
+ *   patch:
+ *     summary: Desativar administrador
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do administrador
+ *     responses:
+ *       200:
+ *         description: Administrador desativado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Administrador desativado com sucesso"
+ *                 administrador:
+ *                   $ref: '#/components/schemas/Administrador'
+ *       404:
+ *         description: Administrador não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.patch("/:id/desativar", administradorController.desativarAdministrador);
+
+/**
+ * @swagger
+ * /administradores/{id}:
+ *   delete:
+ *     summary: Deletar administrador
+ *     tags: [Administradores]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID do administrador
+ *     responses:
+ *       200:
+ *         description: Administrador removido com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Administrador removido com sucesso"
+ *       404:
+ *         description: Administrador não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+router.delete("/:id", administradorController.deleteAdministrador);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,8 @@ import userRoutes from "./userRoutes";
 import projetoRoutes from "./projetoRoutes";
 import sprintRoutes from "./sprintRoutes";
 import tarefaRoutes from "./tarefaRoutes";
+import administradorRoutes from "./administradorRoutes";
+import administradorExtendedRoutes from "./administradorExtendedRoutes";
 
 /**
  * @swagger
@@ -15,6 +17,8 @@ import tarefaRoutes from "./tarefaRoutes";
  *     description: Operações relacionadas às sprints
  *   - name: Tarefas
  *     description: Operações relacionadas às tarefas
+ *   - name: Administradores
+ *     description: Operações relacionadas aos administradores
  */
 
 const router = Router();
@@ -24,5 +28,7 @@ router.use("/users", userRoutes);
 router.use("/projetos", projetoRoutes);
 router.use("/sprints", sprintRoutes);
 router.use("/tarefas", tarefaRoutes);
+router.use("/administradores", administradorRoutes);
+router.use("/administradores", administradorExtendedRoutes);
 
 export default router;

--- a/src/services/administradorService.ts
+++ b/src/services/administradorService.ts
@@ -1,0 +1,218 @@
+import { AdministradorRepository, UpdateAdministradorData } from "../repositories/administradorRepository";
+
+export interface CreateAdministradorDTO {
+    userId: number;
+    nivel: 'super' | 'moderador' | 'suporte';
+    permissoes?: string[];
+    ativo?: boolean;
+}
+
+export interface UpdateAdministradorDTO {
+    nivel?: 'super' | 'moderador' | 'suporte';
+    permissoes?: string[];
+    ativo?: boolean;
+}
+
+// Constantes de permissões disponíveis
+export const PERMISSOES_DISPONIVEIS = [
+    'gerenciar_usuarios',
+    'gerenciar_projetos',
+    'gerenciar_sprints',
+    'gerenciar_tarefas',
+    'gerenciar_administradores',
+    'visualizar_relatorios',
+    'gerenciar_sistema',
+    'aprovar_projetos',
+    'deletar_dados'
+] as const;
+
+export class AdministradorService {
+    private administradorRepository: AdministradorRepository;
+
+    constructor() {
+        this.administradorRepository = new AdministradorRepository();
+    }
+
+    async createAdministrador(data: CreateAdministradorDTO) {
+        try {
+            // Validações de negócio
+            if (!data.userId || data.userId <= 0) {
+                throw new Error("ID do usuário é obrigatório e deve ser válido");
+            }
+
+            // Verificar se o usuário já é administrador
+            const administradorExistente = await this.administradorRepository.getAdministradorByUserId(data.userId);
+            if (administradorExistente) {
+                throw new Error("Este usuário já é um administrador");
+            }
+
+            // Validar permissões se fornecidas
+            if (data.permissoes && data.permissoes.length > 0) {
+                const permissoesInvalidas = data.permissoes.filter(
+                    permissao => !PERMISSOES_DISPONIVEIS.includes(permissao as any)
+                );
+                if (permissoesInvalidas.length > 0) {
+                    throw new Error(`Permissões inválidas: ${permissoesInvalidas.join(', ')}`);
+                }
+            }
+
+            // Definir permissões padrão baseadas no nível
+            let permissoesPadrao = data.permissoes || [];
+            if (!data.permissoes || data.permissoes.length === 0) {
+                switch (data.nivel) {
+                    case 'super':
+                        permissoesPadrao = [...PERMISSOES_DISPONIVEIS];
+                        break;
+                    case 'moderador':
+                        permissoesPadrao = ['gerenciar_usuarios', 'gerenciar_projetos', 'gerenciar_sprints', 'visualizar_relatorios'];
+                        break;
+                    case 'suporte':
+                        permissoesPadrao = ['visualizar_relatorios'];
+                        break;
+                }
+            }
+
+            const administrador = await this.administradorRepository.createAdministrador(
+                data.userId,
+                data.nivel,
+                permissoesPadrao,
+                data.ativo !== undefined ? data.ativo : true
+            );
+
+            return administrador;
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async getAllAdministradores() {
+        try {
+            return await this.administradorRepository.getAllAdministradores();
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async getAdministradorById(id: number) {
+        try {
+            if (!id || id <= 0) {
+                throw new Error("ID do administrador inválido");
+            }
+
+            const administrador = await this.administradorRepository.getAdministradorById(id);
+            if (!administrador) {
+                throw new Error("Administrador não encontrado");
+            }
+
+            return administrador;
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async getAdministradorByUserId(userId: number) {
+        try {
+            if (!userId || userId <= 0) {
+                throw new Error("ID do usuário inválido");
+            }
+
+            return await this.administradorRepository.getAdministradorByUserId(userId);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async getAdministradoresByNivel(nivel: 'super' | 'moderador' | 'suporte') {
+        try {
+            return await this.administradorRepository.getAdministradoresByNivel(nivel);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async getAdministradoresAtivos() {
+        try {
+            return await this.administradorRepository.getAdministradoresAtivos();
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async updateAdministrador(id: number, data: UpdateAdministradorDTO) {
+        try {
+            if (!id || id <= 0) {
+                throw new Error("ID do administrador inválido");
+            }
+
+            // Validar permissões se fornecidas
+            if (data.permissoes && data.permissoes.length > 0) {
+                const permissoesInvalidas = data.permissoes.filter(
+                    permissao => !PERMISSOES_DISPONIVEIS.includes(permissao as any)
+                );
+                if (permissoesInvalidas.length > 0) {
+                    throw new Error(`Permissões inválidas: ${permissoesInvalidas.join(', ')}`);
+                }
+            }
+
+            const updatedAdministrador = await this.administradorRepository.updateAdministrador(id, data);
+            return updatedAdministrador;
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async ativarAdministrador(id: number) {
+        try {
+            if (!id || id <= 0) {
+                throw new Error("ID do administrador inválido");
+            }
+
+            return await this.administradorRepository.ativarAdministrador(id);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async desativarAdministrador(id: number) {
+        try {
+            if (!id || id <= 0) {
+                throw new Error("ID do administrador inválido");
+            }
+
+            return await this.administradorRepository.desativarAdministrador(id);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async deleteAdministrador(id: number) {
+        try {
+            if (!id || id <= 0) {
+                throw new Error("ID do administrador inválido");
+            }
+
+            const result = await this.administradorRepository.deleteAdministrador(id);
+            return result;
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async verificarPermissao(userId: number, permissao: string): Promise<boolean> {
+        try {
+            if (!userId || userId <= 0) {
+                return false;
+            }
+
+            return await this.administradorRepository.verificarPermissao(userId, permissao);
+        } catch (error) {
+            return false;
+        }
+    }
+
+    async getPermissoesDisponiveis() {
+        return PERMISSOES_DISPONIVEIS;
+    }
+}
+
+export default AdministradorService;


### PR DESCRIPTION
- Create Administrador Sequelize model with user relationship
- Implement three access levels: super, moderador, suporte
- Add granular permissions array for specific access control
- Include active/inactive status management
- Add timestamps for creation and update tracking